### PR TITLE
Remove -lXi and -lXmu

### DIFF
--- a/fourier/Makefile
+++ b/fourier/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -Wall -ansi -pedantic -ggdb --std=c++11
 DOCSGEN = doxygen
-LDFLAGS	= -L/usr/X11R6/lib -lglut -lGL -lGLU -lXi -lXmu -lm
+LDFLAGS	= -L/usr/X11R6/lib -lglut -lGL -lGLU -lm
 SRC = src
 OBJ = obj
 BIN = bin

--- a/orbits/Makefile
+++ b/orbits/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -Wall -ansi -pedantic -ggdb
 LDFLAGS = -lm
-GLFLAGS = -L/usr/X11R6/lib -lglut -lGL -lGLU -lXi -lXmu
+GLFLAGS = -L/usr/X11R6/lib -lglut -lGL -lGLU
 DOCSGEN = doxygen
 
 SRC = src


### PR DESCRIPTION
From the Makefiles for "fourier" and "orbits". These flags do not appear
to be necessary, and they prevent compilation on some CMS machines.
